### PR TITLE
fix: logger dying, script referencing dlls, removed some dead code

### DIFF
--- a/src/Informedica.GenOrder.Lib/Scripts/Examples.fsx
+++ b/src/Informedica.GenOrder.Lib/Scripts/Examples.fsx
@@ -1,8 +1,11 @@
 ﻿
 
-//#I __SOURCE_DIRECTORY__
-// Go to load.fsx and send that to FSI first.
-// Running load.fsx in a single time fails.
+// #I __SOURCE_DIRECTORY__
+// The above directive doesn't work anymore, instead
+// the fsi will silent cd to the present script directory
+// but still try to run the below load script first.
+// So first start the fsi, only then you can run the below
+// script.
 #load "load.fsx"
 
 open System
@@ -102,7 +105,6 @@ let logger =
                             msgs.Add(timer.Elapsed.TotalSeconds, m)
                         return! loop timer level msgs
 
-
                     | Report ->
                         printfn "=== Start Report ===\n"
                         msgs 
@@ -119,6 +121,8 @@ let logger =
                         )
                         printfn "\n"
 
+                        return! loop timer level msgs
+
                     | Write path ->
                         msgs 
                         |> Seq.iteri (fun i (t, m) ->
@@ -132,8 +136,6 @@ let logger =
                         )
                         System.IO.File.AppendAllLines(path, ["\n"])
 
-
-                        let timer = Stopwatch.StartNew()
                         return! loop timer level msgs
                 }
             

--- a/src/Informedica.GenOrder.Lib/Scripts/load.fsx
+++ b/src/Informedica.GenOrder.Lib/Scripts/load.fsx
@@ -1,8 +1,12 @@
-// Cannot load this in a single time. 
-// Need to run these loads each at a time
-#load "../../Informedica.Utils.Lib/Scripts/load.fsx"
-#load "../../Informedica.GenUnits.Lib/Scripts/load.fsx"
-#load "../../Informedica.GenSolver.Lib/Scripts/load.fsx"
+
+#r "nuget: MathNet.Numerics.FSharp"
+#r "nuget: FParsec"
+
+
+#r "../../Informedica.Utils.Lib/bin/Debug/net5.0/Informedica.Utils.Lib.dll"
+#r "../../Informedica.GenUnits.Lib/bin/Debug/net5.0/Informedica.GenUnits.Lib.dll"
+#r "../../Informedica.GenSolver.Lib/bin/Debug/net5.0/Informedica.GenSolver.Lib.dll"
+
 // These can be loaded all at once.
 #load "../Types.fs"
 #load "../DateTime.fs"

--- a/src/Informedica.GenSolver.Lib/Scripts/Variable.fsx
+++ b/src/Informedica.GenSolver.Lib/Scripts/Variable.fsx
@@ -1,7 +1,7 @@
 ﻿
-#I __SOURCE_DIRECTORY__
+// #I __SOURCE_DIRECTORY__
 
-#load "../../../.paket/load/netstandard2.1/main.group.fsx"
+#load "load.fsx"
 
 #load "../Utils.fs"
 #load "../Variable.fs"
@@ -23,20 +23,10 @@ let v2 =
     |> Variable.ValueRange.createValueSet 
     |> Variable.createSucc ("vr2" |> Variable.Name.createExc)
 
+open Variable.Operators
 
-v1 * v2
+// Example of long running operation
+v1 ^* v2
 
-
-module ValueRange = Variable.ValueRange
-
-// Test setting min < incr
-
-let vr =
-    1N
-    |> ValueRange.createIncr id (string >> exn >> raise)
-    |> ValueRange.minIncrValueRange (1N |> Variable.ValueRange.createMin true)
-
-vr 
-|> ValueRange.setMin (1N/10N |> Variable.ValueRange.createMin true)
 
 

--- a/src/Informedica.GenSolver.Lib/Scripts/load-utils.fsx
+++ b/src/Informedica.GenSolver.Lib/Scripts/load-utils.fsx
@@ -1,1 +1,0 @@
-#load "../../Informedica.Utils.Lib/Scripts/load.fsx"

--- a/src/Informedica.GenSolver.Lib/Scripts/load.fsx
+++ b/src/Informedica.GenSolver.Lib/Scripts/load.fsx
@@ -1,4 +1,9 @@
-// Warning: generated file; your changes could be lost when a new file is generated.
+
+#r "nuget: MathNet.Numerics.FSharp"
+#r "nuget: FParsec"
+
+#r "../../Informedica.Utils.Lib/bin/Debug/net5.0/Informedica.Utils.Lib.dll"
+#r "../../Informedica.GenUnits.Lib/bin/Debug/net5.0/Informedica.GenUnits.Lib.dll"
 
 #load "../Types.fs"
 #load "../Utils.fs"

--- a/src/Informedica.GenUnits.Lib/Scripts/Api.fsx
+++ b/src/Informedica.GenUnits.Lib/Scripts/Api.fsx
@@ -2,7 +2,6 @@
 //#I "C:\Development\Informedica\libs\GenUnits\src\Informedica.GenUnits.Lib\scripts"
 //#I __SOURCE_DIRECTORY__
 
-#load "load-utils.fsx"
 #load "load.fsx"
 
 open MathNet.Numerics
@@ -12,9 +11,7 @@ open Informedica.Utils.Lib.BCL
 
 Api.eval "1 mg[Mass] / 1 piece[General]"
 |> (/) (Api.eval "1 mg[Mass] / 1 mg[Mass]")
-|> ValueUnit.toString ValueUnit.Units.English ValueUnit.Units.Verbal.Short
+|> ValueUnit.toStringEngShort
 
 Api.eval "100 mg[Mass] * 200 mg[Mass] / 5 ml[Volume] / 10 times[Count]"
-|> ValueUnit.toString ValueUnit.Units.English ValueUnit.Units.Verbal.Short
-
-
+|> ValueUnit.toStringEngShort

--- a/src/Informedica.GenUnits.Lib/Scripts/EqualGroupTest.fsx
+++ b/src/Informedica.GenUnits.Lib/Scripts/EqualGroupTest.fsx
@@ -3,7 +3,6 @@
 
 #r "nuget: Unquote"
 
-#load "load-utils.fsx"
 #load "load.fsx"
 
 open MathNet.Numerics

--- a/src/Informedica.GenUnits.Lib/Scripts/Examples.fsx
+++ b/src/Informedica.GenUnits.Lib/Scripts/Examples.fsx
@@ -1,6 +1,5 @@
 //#I __SOURCE_DIRECTORY__
 
-#load "load-utils.fsx"
 #load "load.fsx"
 
 #time

--- a/src/Informedica.GenUnits.Lib/Scripts/Parser.fsx
+++ b/src/Informedica.GenUnits.Lib/Scripts/Parser.fsx
@@ -1,7 +1,6 @@
 
 //#I __SOURCE_DIRECTORY__
 
-#load "load-utils.fsx"
 #load "load.fsx"
 
 open MathNet.Numerics

--- a/src/Informedica.GenUnits.Lib/Scripts/Simplify.fsx
+++ b/src/Informedica.GenUnits.Lib/Scripts/Simplify.fsx
@@ -1,7 +1,6 @@
 
 //#I __SOURCE_DIRECTORY__
 
-#load "load-utils.fsx"
 #load "load.fsx"
 
 open MathNet.Numerics

--- a/src/Informedica.GenUnits.Lib/Scripts/ValueUnit.fsx
+++ b/src/Informedica.GenUnits.Lib/Scripts/ValueUnit.fsx
@@ -1,7 +1,6 @@
 
 //#I __SOURCE_DIRECTORY__
 
-#load "load-utils.fsx"
 #load "load.fsx"
 
 open MathNet.Numerics

--- a/src/Informedica.GenUnits.Lib/Scripts/load-utils.fsx
+++ b/src/Informedica.GenUnits.Lib/Scripts/load-utils.fsx
@@ -1,2 +1,0 @@
-
-#load "../../Informedica.Utils.Lib/Scripts/load.fsx"

--- a/src/Informedica.GenUnits.Lib/Scripts/load.fsx
+++ b/src/Informedica.GenUnits.Lib/Scripts/load.fsx
@@ -1,5 +1,8 @@
 
+#r "nuget: MathNet.Numerics.FSharp"
 #r "nuget: FParsec"
+
+#r "../../Informedica.Utils.Lib/bin/Debug/net5.0/Informedica.Utils.Lib.dll"
 
 #load "../AssemblyInfo.fs" 
 #load "../ValueUnit.fs" 


### PR DESCRIPTION
## Proposed Changes

The script files referenced source files from different projects, that was slow, know they reference the dlls. Note: so you need to compile the external projects first!

Fixed a problem with the logger agent, dying after reporting.

## Types of changes

What types of changes does your code introduce to Informedica.GenPres.Lib?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


